### PR TITLE
Improve find command to be case insensitive

### DIFF
--- a/src/main/java/duke/task/Task.java
+++ b/src/main/java/duke/task/Task.java
@@ -38,7 +38,8 @@ public class Task {
      * @return True if the task name contains this phrase, false otherwise.
      */
     public boolean containsPhrase(String phrase) {
-        return taskName.contains(phrase);
+        String capsInsensitiveTaskName = taskName.toLowerCase();
+        return capsInsensitiveTaskName.contains(phrase.toLowerCase());
     }
 
     /**


### PR DESCRIPTION
Find command is case sensitive.

If the user enters a key phrase, the find command only returns
tasks that fit the phrase exactly. (e.g. find book does not return
the task Return Book)

Let's change containsPhrase method in Task to be case insensitive.

This will solve the aforementioned problem of case sensitive keyphrases.

Note: This commit is made on this branch so that I can create a pull
request for branch-A-Streams, since my code already uses streams
and hence was identical to the master branch.