### PR TITLE
Add ability to specify command shortcuts

### DIFF
--- a/src/main/java/duke/command/AddAliasCommand.java
+++ b/src/main/java/duke/command/AddAliasCommand.java
@@ -1,0 +1,43 @@
+package duke.command;
+
+import java.io.IOException;
+
+import duke.task.TaskList;
+import duke.util.AliasHandler;
+import duke.util.Parser;
+import duke.util.Storage;
+import duke.util.Ui;
+
+/**
+ * A class that represents the command when the user types in 'addalias'.
+ */
+public class AddAliasCommand extends Command {
+
+    /**
+     * Creates an AddAliasCommand, which relies on user inputs to function.
+     *
+     * @param input A string containing the user's input.
+     */
+    public AddAliasCommand(String input) {
+        super(input);
+    }
+
+    /**
+     * Adds an alias and saves the new alias to the config file.
+     *
+     * @param taskList   The current list of tasks from the user.
+     * @param ui      An object that handles all UI related functionality. (e.g. printing)
+     * @param storage An object that handles all save/load related functionality.
+     * @return The input task list and an output message.
+     * @throws IOException If an error occurs during the save operation.
+     */
+    @Override
+    public TaskList execute(TaskList taskList, Ui ui, Storage storage) throws IOException {
+        AliasHandler aliasHandler = Parser.getAliasHandler();
+        AliasHandler newAliasHandler = aliasHandler.addAlias(ui, input);
+        storage.saveAliasesToFile(newAliasHandler);
+        Parser.setAliasHandler(newAliasHandler);
+        String message = newAliasHandler.getRecentMessage();
+        return new TaskList(taskList, message);
+    }
+}

--- a/src/main/java/duke/command/AddTaskCommand.java
+++ b/src/main/java/duke/command/AddTaskCommand.java
@@ -10,14 +10,14 @@ import duke.util.Ui;
 /**
  * A class that represents the command when the user types in 'todo', 'deadline' or 'event'.
  */
-public class AddCommand extends Command {
+public class AddTaskCommand extends Command {
 
     /**
-     * Creates an AddCommand, which relies on user inputs to function.
+     * Creates an AddTaskCommand, which relies on user inputs to function.
      *
      * @param input A string containing the user's input.
      */
-    public AddCommand(String input) {
+    public AddTaskCommand(String input) {
         super(input);
     }
 

--- a/src/main/java/duke/command/DeleteAliasCommand.java
+++ b/src/main/java/duke/command/DeleteAliasCommand.java
@@ -1,0 +1,43 @@
+package duke.command;
+
+import java.io.IOException;
+
+import duke.task.TaskList;
+import duke.util.AliasHandler;
+import duke.util.Parser;
+import duke.util.Storage;
+import duke.util.Ui;
+
+/**
+ * A class that represents the command when the user types in 'deletealias'.
+ */
+public class DeleteAliasCommand extends Command {
+
+    /**
+     * Creates an DeleteAliasCommand, which relies on user inputs to function.
+     *
+     * @param input A string containing the user's input.
+     */
+    public DeleteAliasCommand(String input) {
+        super(input);
+    }
+
+    /**
+     * Deletes an alias, as well as remove it from the config file.
+     *
+     * @param taskList   The current list of tasks from the user.
+     * @param ui      An object that handles all UI related functionality. (e.g. printing)
+     * @param storage An object that handles all save/load related functionality.
+     * @return The input task list and an output message.
+     * @throws IOException If an error occurs during the save operation.
+     */
+    @Override
+    public TaskList execute(TaskList taskList, Ui ui, Storage storage) throws IOException {
+        AliasHandler aliasHandler = Parser.getAliasHandler();
+        AliasHandler newAliasHandler = aliasHandler.deleteAlias(ui, input);
+        storage.saveAliasesToFile(newAliasHandler);
+        Parser.setAliasHandler(newAliasHandler);
+        String message = newAliasHandler.getRecentMessage();
+        return new TaskList(taskList, message);
+    }
+}

--- a/src/main/java/duke/command/DeleteTaskCommand.java
+++ b/src/main/java/duke/command/DeleteTaskCommand.java
@@ -9,14 +9,14 @@ import duke.util.Ui;
 /**
  * A class that represents the command when the user types in 'delete'.
  */
-public class DeleteCommand extends Command {
+public class DeleteTaskCommand extends Command {
 
     /**
-     * Creates a DeleteCommand, which relies on user inputs to function.
+     * Creates a DeleteTaskCommand, which relies on user inputs to function.
      *
      * @param input A string containing the user's input.
      */
-    public DeleteCommand(String input) {
+    public DeleteTaskCommand(String input) {
         super(input);
     }
 

--- a/src/main/java/duke/command/ListAliasCommand.java
+++ b/src/main/java/duke/command/ListAliasCommand.java
@@ -1,0 +1,29 @@
+package duke.command;
+
+import duke.task.TaskList;
+import duke.util.AliasHandler;
+import duke.util.Parser;
+import duke.util.Storage;
+import duke.util.Ui;
+
+/**
+ * A class that represents the command when the user types in 'listalias'.
+ */
+public class ListAliasCommand extends Command {
+
+    /**
+     * Displays all aliases that the user has configured.
+     *
+     * @param taskList   The current list of tasks from the user.
+     * @param ui      An object that handles all UI related functionality. (e.g. printing)
+     * @param storage An object that handles all save/load related functionality.
+     * @return The input task list with an output message.
+     */
+    @Override
+    public TaskList execute(TaskList taskList, Ui ui, Storage storage) {
+        AliasHandler aliasHandler = Parser.getAliasHandler();
+        String message = ui.showMessage("Here are your configured aliases:")
+                + ui.showMessage(aliasHandler.toString());
+        return new TaskList(taskList, message);
+    }
+}

--- a/src/main/java/duke/util/AliasHandler.java
+++ b/src/main/java/duke/util/AliasHandler.java
@@ -1,0 +1,222 @@
+package duke.util;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+public class AliasHandler {
+    // Stores aliases in the form of: alias(key):command(value)
+    private final HashMap<String, String> aliasHashMap;
+    private final String recentMessage;
+
+    /**
+     * Creates an alias handler with no aliases.
+     */
+    public AliasHandler() {
+        this.aliasHashMap = new HashMap<>();
+        this.recentMessage = "";
+    }
+
+    /**
+     * Creates an alias handler with aliases.
+     *
+     * @param aliasHashMap  A hashmap that matches aliases to corresponding commands.
+     */
+    public AliasHandler(HashMap<String, String> aliasHashMap) {
+        this.aliasHashMap = aliasHashMap;
+        this.recentMessage = "";
+    }
+
+    /**
+     * Creates an alias handler with aliases and an output message.
+     *
+     * @param aliasHashMap  A hashmap that matches aliases to corresponding commands.
+     * @param recentMessage A string generated from running a command.
+     */
+    public AliasHandler(HashMap<String, String> aliasHashMap, String recentMessage) {
+        this.aliasHashMap = aliasHashMap;
+        this.recentMessage = recentMessage;
+    }
+
+    /**
+     * Returns the command corresponding to the given alias.
+     * If the alias given does not correspond to any command, the input alias itself
+     * will be returned.
+     *
+     * @param input A string representing the command for which the aliases are being checked.
+     * @return The command string that the alias corresponds to, or the input alias
+     * if there is no such association.
+     */
+    public String convertAlias(String input) {
+        boolean isAlias = aliasHashMap.containsKey(input);
+        if (!isAlias) {
+            return input;
+        }
+        return aliasHashMap.get(input);
+    }
+
+    /**
+     * Adds an alias which corresponds to a given command.
+     * This will work if the user chooses to add an alias to an alias.
+     * E.g. exit is added as an alias for bye. Then quit can be added as an alias for exit,
+     * while having the same functionality of bye.
+     * Aliases are not case sensitive. (e.g. quit is treated the same as QUIT)
+     *
+     * @param input String containing user input.
+     * @return A new AliasHandler instance containing the new task and an output message.
+     * @throws DukeException If input contains |, or is in an invalid format.
+     */
+    public AliasHandler addAlias(Ui ui, String input) throws DukeException {
+        HashMap<String, String> newAliasHashMap = new HashMap<>(this.aliasHashMap);
+        if (input.contains("|")) {
+            throw new DukeException("Input contains |, which is an invalid/reserved character.");
+        }
+        String[] splitInputs = input.split(" ");
+        if (splitInputs.length != 3) {
+            throw new DukeException("Input should be of the format: addalias [command] [alias]");
+        }
+        String alias = splitInputs[2].toLowerCase();
+        if (isCommandKeyword(alias)) {
+            throw new DukeException("This alias is already reserved for an actual command.");
+        }
+        if (aliasHashMap.containsKey(alias)) {
+            String errorMessage = String.format("Alias %s already corresponds to command %s.",
+                    alias, aliasHashMap.get(alias));
+            throw new DukeException(errorMessage);
+        }
+        String command = convertAlias(splitInputs[1]);
+        // If the command given is invalid, this throws a DukeException
+        Parser.parseCommandFromInput(command);
+
+        newAliasHashMap.put(alias, command);
+        String message = ui.showAddAliasMessage(alias, command);
+        return new AliasHandler(newAliasHashMap, message);
+    }
+
+    /**
+     * Checks if an alias conflicts with an actual command word.
+     *
+     * @param alias An input string representing an alias.
+     * @return True if the alias clashes with an actual command, false otherwise.
+     */
+    private boolean isCommandKeyword(String alias) {
+        switch (alias) {
+        case "addalias":
+        case "bye":
+        case "list":
+        case "listalias":
+        case "done":
+        case "todo":
+        case "deadline":
+        case "event":
+        case "delete":
+        case "deletealias":
+        case "ondate":
+        case "due":
+        case "find":
+            return true;
+        default:
+            return false;
+        }
+    }
+
+    /**
+     * Deletes an alias which corresponds to a given command.
+     * Aliases are not case sensitive. (e.g. quit is treated the same as QUIT)
+     *
+     * @param input String containing user input.
+     * @return A new AliasHandler instance with the selected alias removed and an output message.
+     * @throws DukeException If input contains |, or is in an invalid format.
+     */
+    public AliasHandler deleteAlias(Ui ui, String input) throws DukeException {
+        HashMap<String, String> newAliasHashMap = new HashMap<>(this.aliasHashMap);
+        String[] splitInputs = input.split(" ");
+        if (splitInputs.length != 2) {
+            throw new DukeException("Input should be of the format: deletealias [alias]");
+        }
+        String alias = splitInputs[1].toLowerCase();
+        if (!aliasHashMap.containsKey(alias)) {
+            String errorMessage = String.format("Alias %s does not correspond to any command.",
+                    alias);
+            throw new DukeException(errorMessage);
+        }
+        String command = newAliasHashMap.remove(alias);
+        String message = ui.showDeleteAliasMessage(alias, command);
+        return new AliasHandler(newAliasHashMap, message);
+    }
+
+    /**
+     * Gets the string message generated after running a command.
+     *
+     * @return A string generated after running a command.
+     */
+    public String getRecentMessage() {
+        return recentMessage;
+    }
+
+    /**
+     * Converts the alias data into its corresponding config file data format.
+     *
+     * @return A string to represent the data of all aliases for the config file.
+     */
+    public String toConfigData() {
+        String[] aliases = aliasHashMap.keySet().toArray(new String[0]);
+        StringBuilder dataString = new StringBuilder();
+        for (String alias : aliases) {
+            String command = aliasHashMap.get(alias).toLowerCase();
+            dataString.append(alias)
+                    .append("|")
+                    .append(command)
+                    .append(System.lineSeparator());
+        }
+        return dataString.toString().trim();
+    }
+
+    /**
+     * Converts the AliasHandler data into a string format.
+     * The aliases are listed in the following format:
+     * commandKeyword1:
+     * 1. alias1
+     * 2. alias2
+     * commandKeyword2:
+     * 1. alias1
+     * 2. alias2
+     * ...and so on and so forth.
+     *
+     * @return A string representation of the AliasHandler instance.
+     */
+    @Override
+    public String toString() {
+        String[] aliases = aliasHashMap.keySet().toArray(new String[0]);
+        if (aliases.length == 0) {
+            return "No aliases found.";
+        }
+        StringBuilder dataString = new StringBuilder();
+        // Group up all aliases by the command they correspond to
+        HashMap<String, List<String>> commandHashMap = new HashMap<>();
+        for (String alias : aliases) {
+            String command = aliasHashMap.get(alias).toLowerCase();
+            // If this alias is the first one that corresponds to this command,
+            // initialize the arraylist
+            List<String> aliasList = new ArrayList<>();
+            // Else, get the existing list of aliases for this command
+            if (commandHashMap.containsKey(command)) {
+                aliasList = commandHashMap.get(command);
+            }
+            aliasList.add(alias);
+            commandHashMap.put(command, aliasList);
+        }
+
+        String[] commands = commandHashMap.keySet().toArray(new String[0]);
+        for (String command : commands) {
+            dataString.append(command)
+                    .append(":\n");
+            List<String> aliasList = commandHashMap.get(command);
+            for (int i = 0; i < aliasList.size(); i++) {
+                String aliasString = String.format("\t%d. %s\n", i + 1, aliasList.get(i));
+                dataString.append(aliasString);
+            }
+        }
+        return dataString.toString().trim();
+    }
+}

--- a/src/main/java/duke/util/Parser.java
+++ b/src/main/java/duke/util/Parser.java
@@ -4,13 +4,16 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.format.DateTimeParseException;
 
-import duke.command.AddCommand;
+import duke.command.AddAliasCommand;
+import duke.command.AddTaskCommand;
 import duke.command.ByeCommand;
 import duke.command.Command;
-import duke.command.DeleteCommand;
+import duke.command.DeleteAliasCommand;
+import duke.command.DeleteTaskCommand;
 import duke.command.DoneCommand;
 import duke.command.DueCommand;
 import duke.command.FindCommand;
+import duke.command.ListAliasCommand;
 import duke.command.ListCommand;
 import duke.command.OnDateCommand;
 
@@ -19,6 +22,25 @@ import duke.command.OnDateCommand;
  * and commands from user input.
  */
 public class Parser {
+    private static AliasHandler aliasHandler = new AliasHandler();
+
+    /**
+     * Assigns an AliasHandler object that contains a list of aliases to Parser.
+     *
+     * @param aliasHandler An AliasHandler object containing a list of aliases.
+     */
+    public static void setAliasHandler(AliasHandler aliasHandler) {
+        Parser.aliasHandler = aliasHandler;
+    }
+
+    /**
+     * Gets an AliasHandler object assigned to Parser that contains a list of aliases.
+     *
+     * @return An AliasHandler object containing a list of aliases.
+     */
+    public static AliasHandler getAliasHandler() {
+        return aliasHandler;
+    }
 
     /**
      * Converts a string representing a date into a LocalDate object.
@@ -52,31 +74,41 @@ public class Parser {
 
     /**
      * Parses the user's input to determine what command is being called.
+     * Command are not case sensitive. (e.g. bye is treated the same as BYE)
      *
      * @param input Input that contains the user's command.
      * @return Command object that can be used to execute the related function.
      * @throws DukeException If an invalid command is given.
      */
     public static Command parseCommandFromInput(String input) throws DukeException {
-        String commandString = input.split(" ")[0].toUpperCase();
+        String inputString = input.split(" ")[0].toLowerCase();
+        String commandString = aliasHandler.convertAlias(inputString);
+        // Note: any changes made to this switch-case should also be made
+        // to the switch-case in AliasHandler method isCommandKeyWord
         switch (commandString) {
-        case "BYE":
+        case "addalias":
+            return new AddAliasCommand(input);
+        case "bye":
             return new ByeCommand();
-        case "LIST":
+        case "list":
             return new ListCommand();
-        case "DONE":
+        case "listalias":
+            return new ListAliasCommand();
+        case "done":
             return new DoneCommand(input);
-        case "TODO":
-        case "DEADLINE":
-        case "EVENT":
-            return new AddCommand(input);
-        case "DELETE":
-            return new DeleteCommand(input);
-        case "ONDATE":
+        case "todo":
+        case "deadline":
+        case "event":
+            return new AddTaskCommand(input);
+        case "delete":
+            return new DeleteTaskCommand(input);
+        case "deletealias":
+            return new DeleteAliasCommand(input);
+        case "ondate":
             return new OnDateCommand(input);
-        case "DUE":
+        case "due":
             return new DueCommand(input);
-        case "FIND":
+        case "find":
             return new FindCommand(input);
         default:
             throw new DukeException("You have entered an invalid command.");

--- a/src/main/java/duke/util/Ui.java
+++ b/src/main/java/duke/util/Ui.java
@@ -74,6 +74,32 @@ public class Ui {
     }
 
     /**
+     * Displays a formatted message. Called when a new alias is added.
+     *
+     * @param alias The alias being added.
+     * @param command The command that corresponds to the alias being added.
+     * @return A formatted string.
+     */
+    public String showAddAliasMessage(String alias, String command) {
+        String outputString = String.format("Got it. Alias %s now corresponds to command %s.",
+                alias, command);
+        return showMessage(outputString);
+    }
+
+    /**
+     * Displays a formatted message. Called when an alias is deleted.
+     *
+     * @param alias The alias being deleted.
+     * @param command The command that corresponds to the alias being deleted.
+     * @return A formatted string.
+     */
+    public String showDeleteAliasMessage(String alias, String command) {
+        String outputString = String.format("Got it. Alias %s no longer corresponds to command %s.",
+                alias, command);
+        return showMessage(outputString);
+    }
+
+    /**
      * Returns a formatted error string.
      *
      * @param errorMessage Error string that is to be formatted and printed.
@@ -88,9 +114,18 @@ public class Ui {
      *
      * @return A formatted error string.
      */
-    public String showFileNotFoundError() {
+    public String showSaveFileNotFoundError() {
         return String.format(FORMAT, "This appears to be your first time using Duke.")
-                + String.format(FORMAT, "A save file will be created to save your tasks when you first add a task.");
+                + String.format(FORMAT, "A save file will be created to save your tasks.");
+    }
+
+    /**
+     * Returns a formatted error string. Is called if the config file does not exist.
+     *
+     * @return A formatted error string.
+     */
+    public String showConfigFileNotFoundError() {
+        return String.format(FORMAT, "A config file will be created to save your settings.");
     }
 
     /**
@@ -99,10 +134,23 @@ public class Ui {
      *
      * @return A formatted error string.
      */
-    public String showLoadingError(String errorMessage) {
+    public String showSaveFileLoadingError(String errorMessage) {
         return showError(errorMessage)
                 + String.format(FORMAT, "This appears to be an error with your save file.")
                 + String.format(FORMAT, "Either edit data/tasks.txt to rectify the error, or delete it.")
                 + String.format(FORMAT, "For now, you'll start with an empty task list.");
+    }
+
+    /**
+     * Returns a formatted error string. Is called if the config file contains incorrectly
+     * formatted data.
+     *
+     * @return A formatted error string.
+     */
+    public String showConfigLoadingError(String errorMessage) {
+        return showError(errorMessage)
+                + String.format(FORMAT, "This appears to be an error with your config file.")
+                + String.format(FORMAT, "Either edit data/config.txt to rectify the error, or delete it.")
+                + String.format(FORMAT, "For now, you'll start without any aliases for your commands.");
     }
 }

--- a/src/test/java/duke/ParserTest.java
+++ b/src/test/java/duke/ParserTest.java
@@ -9,9 +9,9 @@ import java.time.LocalTime;
 
 import org.junit.jupiter.api.Test;
 
-import duke.command.AddCommand;
+import duke.command.AddTaskCommand;
 import duke.command.ByeCommand;
-import duke.command.DeleteCommand;
+import duke.command.DeleteTaskCommand;
 import duke.command.DoneCommand;
 import duke.command.DueCommand;
 import duke.command.ListCommand;
@@ -119,7 +119,7 @@ public class ParserTest {
     @Test
     public void parseCommandFromInput_todoCommand_success() {
         try {
-            assertTrue(Parser.parseCommandFromInput("todo") instanceof AddCommand);
+            assertTrue(Parser.parseCommandFromInput("todo") instanceof AddTaskCommand);
         } catch (Exception e) {
             fail();
         }
@@ -128,7 +128,7 @@ public class ParserTest {
     @Test
     public void parseCommandFromInput_deadlineCommand_success() {
         try {
-            assertTrue(Parser.parseCommandFromInput("deadline") instanceof AddCommand);
+            assertTrue(Parser.parseCommandFromInput("deadline") instanceof AddTaskCommand);
         } catch (Exception e) {
             fail();
         }
@@ -137,7 +137,7 @@ public class ParserTest {
     @Test
     public void parseCommandFromInput_eventCommand_success() {
         try {
-            assertTrue(Parser.parseCommandFromInput("event") instanceof AddCommand);
+            assertTrue(Parser.parseCommandFromInput("event") instanceof AddTaskCommand);
         } catch (Exception e) {
             fail();
         }
@@ -146,7 +146,7 @@ public class ParserTest {
     @Test
     public void parseCommandFromInput_deleteCommand_success() {
         try {
-            assertTrue(Parser.parseCommandFromInput("delete") instanceof DeleteCommand);
+            assertTrue(Parser.parseCommandFromInput("delete") instanceof DeleteTaskCommand);
         } catch (Exception e) {
             fail();
         }


### PR DESCRIPTION
Users can only use the commands specified in the program.

Adding the ability for users to specify their own shortcuts
(or aliases) for commands will improve the user's workflow by
making the syntax more friendly overall.

Let's
* Add a class to handle aliases
* Add methods to save and load aliases to and from a config file
* Modify certain methods in TaskList to take into consideration
aliases of variable length

Having a dedicated class to handle aliases will ensure that
other classes would not get too long, as well as serving as
an encapsulation of alias-related functionality so that any
future modifications made to how aliases are handled will
not cause a cascade of modifications in other classes.